### PR TITLE
Refactor current queue computation logic

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,37 +5,44 @@ import weekOfYear from "dayjs/plugin/weekOfYear";
 
 import PersonCard from "./components/PersonCard";
 
-const FIRST_WEEK = 15;
-
-function App() {
-  dayjs.extend(weekOfYear)
-
-  const frontendQueue = ["Dima", "Leo", "Andrii", "Julio"];
-  const frontendIndexes = Object.keys(frontendQueue);
-
-  const backendQueue = ["Marco", "Leoni", "Sukh", "Daniel"];
-  const backendIndexes = Object.keys(backendQueue);
-
+const useCurrentData = () => {
+  dayjs.extend(weekOfYear);
+ 
+  const FIRST_WEEK = 15;
   const thisWeek = dayjs().week();
   const thisDay = dayjs().format("DD.MM.YYYY");
-  let calculatedWorkWeek = thisWeek;
 
-  if (
-    !frontendIndexes.includes(String(calculatedWorkWeek - FIRST_WEEK))
-    && !backendIndexes.includes(String(calculatedWorkWeek - FIRST_WEEK))
-  ) {
-    calculatedWorkWeek = calculatedWorkWeek - 4;
-  }
+  const frontendQueue = ["Dima", "Leo", "Andrii", "Julio"];
+  const backendQueue = ["Marco", "Leoni", "Sukh", "Daniel"];
 
-  const frontendPerson = frontendQueue[calculatedWorkWeek - FIRST_WEEK];
-  const backendPerson = backendQueue[calculatedWorkWeek - FIRST_WEEK];
+  const getCurrentWeek = () => {
+    // when new year starts
+    if ((thisWeek - FIRST_WEEK) < 1) {
+      return thisWeek;
+    }
+
+    return thisWeek - FIRST_WEEK;
+  };
+ 
+  const frontendPerson = frontendQueue[getCurrentWeek() % frontendQueue.length];
+  const backendPerson = backendQueue[getCurrentWeek() % backendQueue.length];
+
+  return {
+    thisDay,
+    thisWeek,
+    frontendPerson,
+    backendPerson,
+  };
+};
+
+const App = () => {
+  const { thisDay, thisWeek, frontendPerson, backendPerson } = useCurrentData();
 
   return (
     <>
       <header className="header">
         <h1>Week {thisWeek} 🗓️ {thisDay}</h1>
       </header>
-
       <main className="main-wrapper">
         <h2 className="main-wrapper__subtitle">This week representatives</h2>
         <div className="row">


### PR DESCRIPTION
### Description
In scope of this PR I refactor our current "algorithm" of next person computation. Before refactoring we were trapped and when we will reach week #20 we won't be able to calculate next person as we will return non-existent indexes of our squads arrays.
Weekly reusable logic will be the result of this PR. 

### Main points
- move logic into separate function
- drop old implementation with arrays of indexes
- add utility method for returning difference between current week and starter week
- add condition for `thisWeek` less than `FIRST_WEEK` - start of new year

### Questions/thoughts
- are all variables, functions namings acceptable
- on the next iteration we should check if we select correct person when new year starts (avoid repetition)